### PR TITLE
FLEXSIM-12554 -Fix Python connector memory leaks when calling Python from FlexSim

### DIFF
--- a/FlexSimPy/PyConverter.cpp
+++ b/FlexSimPy/PyConverter.cpp
@@ -1,4 +1,5 @@
 #include "PyConverter.h"
+#include "../PyConnector/PyXDecRefPtr.h"
 #include <string>
 #include <codecvt>
 
@@ -33,29 +34,18 @@ PyObject* PyConverter::convertToPyObject(const Variant& v, bool arrayAsTuple)
     }
     case VariantType::Map: {
         Map m = v;
-        PyObject* dict = PyDict_New();
-        if (!dict)
+        PyXDecRefPtr dict(PyDict_New());
+        if (!dict.get())
             return nullptr;
         for (auto iter = m.begin(); iter != m.end(); iter++) {
-            PyObject* key = convertToPyObject(iter.key, true);
-            PyObject* value = convertToPyObject(iter.value, arrayAsTuple);
-            if (!key || !value) {
-                Py_XDECREF(key);
-                Py_XDECREF(value);
-                Py_DECREF(dict);
+            PyXDecRefPtr key(convertToPyObject(iter.key, true));
+            PyXDecRefPtr value(convertToPyObject(iter.value, arrayAsTuple));
+            if (!key || !value)
                 return nullptr;
-            }
-            if (PyDict_SetItem(dict, key, value) != 0) {
-                Py_DECREF(key);
-                Py_DECREF(value);
-                Py_DECREF(dict);
+            if (PyDict_SetItem(dict, key, value) != 0)
                 return nullptr;
-            }
-            
-            Py_DECREF(key);
-            Py_DECREF(value);
         }
-        return dict;
+        return dict.release();
     }
     default: {
         Py_INCREF(Py_None);

--- a/FlexSimPy/PyConverter.cpp
+++ b/FlexSimPy/PyConverter.cpp
@@ -34,10 +34,26 @@ PyObject* PyConverter::convertToPyObject(const Variant& v, bool arrayAsTuple)
     case VariantType::Map: {
         Map m = v;
         PyObject* dict = PyDict_New();
+        if (!dict)
+            return nullptr;
         for (auto iter = m.begin(); iter != m.end(); iter++) {
             PyObject* key = convertToPyObject(iter.key, true);
             PyObject* value = convertToPyObject(iter.value, arrayAsTuple);
-            PyDict_SetItem(dict, key, value);
+            if (!key || !value) {
+                Py_XDECREF(key);
+                Py_XDECREF(value);
+                Py_DECREF(dict);
+                return nullptr;
+            }
+            if (PyDict_SetItem(dict, key, value) != 0) {
+                Py_DECREF(key);
+                Py_DECREF(value);
+                Py_DECREF(dict);
+                return nullptr;
+            }
+            
+            Py_DECREF(key);
+            Py_DECREF(value);
         }
         return dict;
     }

--- a/FlexSimPy/PyConverter.cpp
+++ b/FlexSimPy/PyConverter.cpp
@@ -35,7 +35,7 @@ PyObject* PyConverter::convertToPyObject(const Variant& v, bool arrayAsTuple)
     case VariantType::Map: {
         Map m = v;
         PyXDecRefPtr dict(PyDict_New());
-        if (!dict.get())
+        if (!dict)
             return nullptr;
         for (auto iter = m.begin(); iter != m.end(); iter++) {
             PyXDecRefPtr key(convertToPyObject(iter.key, true));

--- a/PyConnector/PyConnector.cpp
+++ b/PyConnector/PyConnector.cpp
@@ -301,9 +301,12 @@ PyCode::~PyCode()
 Variant PyCode::evaluate(CallPoint* callPoint)
 {
     int numParams = (int)parqty(callPoint);
-    PyGILState_STATE state;
-    if (pyConnector.hasFlexSimPyController)
+    PyGILState_STATE state{};
+    bool gilHeld = false;
+    if (pyConnector.hasFlexSimPyController) {
         state = PyGILState_Ensure();
+        gilHeld = true;
+    }
 
     PyObject* tuple = PyTuple_New(numParams);
 
@@ -319,14 +322,11 @@ Variant PyCode::evaluate(CallPoint* callPoint)
     else {
         PyConnector::printLastPyError();
     }
-    if (pyConnector.hasFlexSimPyController) {
-        // releasing the GIL handles tuple/result memory
+    // Must decref while GIL is held; PyGILState_Release does not free these objects
+    Py_XDECREF(result);
+    Py_XDECREF(tuple);
+    if (gilHeld)
         PyGILState_Release(state);
-    } else {
-        // Otherwise it needs to be handled here
-        Py_XDECREF(result);
-        Py_XDECREF(tuple);
-    }
 
     return returnVal;
 }

--- a/PyConnector/PyConnector.cpp
+++ b/PyConnector/PyConnector.cpp
@@ -308,23 +308,22 @@ Variant PyCode::evaluate(CallPoint* callPoint)
         gilHeld = true;
     }
 
-    PyObject* tuple = PyTuple_New(numParams);
-
-    for (int i = 1; i <= numParams; i++) {
-        PyObject* p = PyConverter::convertToPyObject(_param(i, callPoint));
-        PyTuple_SetItem(tuple, (size_t)i - 1, p);
-    }
-    PyObject* result = PyObject_Call(func, tuple, nullptr);
     Variant returnVal;
-    if (result) {
-        returnVal = PyConverter::convertToVariant(result);
+    {
+        PyXDecRefPtr tuple(PyTuple_New(numParams));
+        for (int i = 1; i <= numParams; i++) {
+            PyObject* p = PyConverter::convertToPyObject(_param(i, callPoint));
+            PyTuple_SetItem(tuple, (size_t)i - 1, p);
+        }
+        PyXDecRefPtr result(PyObject_Call(func, tuple, nullptr));
+        if (result) {
+            returnVal = PyConverter::convertToVariant(result);
+        }
+        else {
+            PyConnector::printLastPyError();
+        }
     }
-    else {
-        PyConnector::printLastPyError();
-    }
-    // Must decref while GIL is held; PyGILState_Release does not free these objects
-    Py_XDECREF(result);
-    Py_XDECREF(tuple);
+    // PyXDecRefPtr destructors run here while GIL is still held
     if (gilHeld)
         PyGILState_Release(state);
 

--- a/PyConnector/PyXDecRefPtr.h
+++ b/PyConnector/PyXDecRefPtr.h
@@ -9,9 +9,19 @@ private:
 public:
 	PyXDecRefPtr() = delete;
 	PyXDecRefPtr(const PyXDecRefPtr& other) = delete;
-	PyXDecRefPtr(PyObject* object) : object(object) {};
+	explicit PyXDecRefPtr(PyObject* object) : object(object) {}
+
 	~PyXDecRefPtr() { Py_XDECREF(object); }
 
-	operator PyObject* () { return object; }
-	PyObject* operator->() { return object; }
+	PyObject* release() noexcept
+	{
+		PyObject* tmp = object;
+		object = nullptr;
+		return tmp;
+	}
+
+	PyObject* get() const noexcept { return object; }
+
+	operator PyObject*() const { return object; }
+	PyObject* operator->() const { return object; }
 };


### PR DESCRIPTION
**Issue :** Passing large maps from FlexScript into Python caused memory to grow quickly. Each key and value was given an extra reference in C when building the Python dict, and those references were never released, so memory never came back even if FlexScript or Python “cleared” the data.
When FlexSimPy is used with the external Python path, every Python call also leaked the argument tuple and the return value. The code assumed releasing the Python GIL would free those objects; it does not.

**Fix:** 
- After each successful dict insert, drop the converter’s extra references to the key and value so they are only owned by the dict (and clean up safely on errors).
- After each Python call, always release the tuple and result object while still holding the GIL, then release the GIL as before.

Card - [[FLEXSIM-12554](https://jira.autodesk.com/browse/FLEXSIM-12554)](url)
Tested with the fsm attached in card.